### PR TITLE
Refactor CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      
-    # install dependencies
-    - name: llvm
-      run: sudo apt-get update && sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+    - uses: silkeh/clang@11
       
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,13 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#configuring-a-build-matrix
-    runs-on: ubuntu-latest
+    # this is a hack, as it includes the latest clang, so we dont have to require it
+    runs-on: macos-latest
 
     steps:
+    # checkout the image to our action
     - uses: actions/checkout@v2
-    - uses: silkeh/clang@11
-      
+
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
       # We'll use this as our working directory for all subsequent commands
@@ -31,13 +32,17 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: |
+        export LLVM_DIR=/usr/local/Cellar/llvm/11.0.0
+        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
     - name: Build
       working-directory: ${{runner.workspace}}/seam/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cmake --build . --config $BUILD_TYPE
+      run: |
+        export LLVM_DIR=/usr/local/Cellar/llvm/11.0.0
+        cmake --build . --config $BUILD_TYPE
 
       # upload artifact, example binary
     - name: Upload Binaries


### PR DESCRIPTION
These changes make the CI faster, as rather than install LLVM & CLang, it comes on a VM with such toolsets already installed. After doing some testing it can take around ~20-30 seconds, rather than 1 minute (30 secs less!!). 